### PR TITLE
updated user routes to add admin only, user only logic inside routes

### DIFF
--- a/server/api/users.js
+++ b/server/api/users.js
@@ -2,38 +2,63 @@ const router = require('express').Router()
 const { User, Cart, Review } = require('../db/models')
 module.exports = router
 
-/*
-As a user, I want to be able to create an account (POST), view my own profile information (GET), edit my profile (PUT), or delete my account (DELETE). I should be able to see all associated information for my account too- my cart, my orders, my reviews, etc.
-*/
-
-// Authorized User Routes
-router.get('/:userId', async (req, res, next) => {
+router.get('/', async (req, res, next) => {
   try {
-    const user = await User.findById(req.params.userId, {
-      include: [{ model: Cart }, { model: Review }]
-    });
-    if (!user) res.sendStatus(404)
-    res.json(user);
+    if (req.user.type === 'admin') {
+      const users = await User.findAll({
+        include: [{ model: Cart }, { model: Review }]
+      });
+      res.json(users)
+    } else {
+      // When an un-authenticated visitor makes a GET request for all users
+      // 403 is a Forbidden page
+      res.sendStatus(403)
+    }
   } catch (err) {
-    next(err);
+    next(err)
   }
 })
 
+router.get('/:userId', async (req, res, next) => {
+  try {
+    if (req.user.type === 'admin' || req.user.id === req.params.userId) {
+      const user = await User.findById(req.params.userId, {
+        include: [{ model: Cart }, { model: Review }]
+      })
+      if (!user) res.sendStatus(404)
+      res.json(user)
+    } else {
+      res.sendStatus(403)
+    }
+  } catch (err) {
+    next(err)
+  }
+})
 
+// To be added later
+// LEAVE IN COMMENT FOR NOW: Admin should only be able to change user TYPE
 router.put('/:userId', async (req, res, next) => {
   try {
-    const user = await User.findById(req.params.userId);
-    const newUser = await user.update(req.body);
-    res.json(newUser);
+    if (req.user.type === 'admin' || req.user.id === req.params.userId) {
+      const user = await User.findById(req.params.userId)
+      const newUser = await user.update(req.body)
+      res.json(newUser)
+    } else {
+      res.sendStatus(403)
+    }
   } catch (err) {
-    next(err);
+    next(err)
   }
 });
 
 router.post('/', async (req, res, next) => {
   try {
-    const user = await User.create(req.body);
-    res.json(user);
+    if (req.user.type === 'admin' || req.user.id === req.params.userId) {
+      const user = await User.create(req.body)
+      res.json(user)
+    } else {
+      res.sendStatus(403)
+    }
   } catch (err) {
     next(err)
   }
@@ -41,26 +66,13 @@ router.post('/', async (req, res, next) => {
 
 router.delete('/:userId', async (req, res, next) => {
   try {
-    const user = await User.findById(req.params.userId);
-    await user.destroy();
-    res.end();
-  } catch (err) {
-    next(err);
-  }
-});
-
-// Admin User Routes
-
-//As an admin, I want to be able to view all registered users (GET), view a single user (GET), promote or demote a user's status (admin vs regular user, PUT), and ban a user(DELETE). All associated information should be loaded when I view the user- their cart, orders, reviews, etc.
-
-// Do I need to write inside my route if usertype === admin then do the route?
-router.get('/', async (req, res, next) => {
-  try {
-    const users = await User.findAll({
-      // Do we want to eager load both the carts and models instantly?
-      include: [{ model: Cart }, { model: Review }]
-    });
-    res.json(users)
+    if (req.user.type === 'admin' || req.user.id === req.params.userId) {
+      const user = await User.findById(req.params.userId)
+      await user.destroy()
+      res.end()
+    } else {
+      res.sendStatus(403)
+    }
   } catch (err) {
     next(err)
   }


### PR DESCRIPTION
I've added the logic of "Admin Only", "User or Admin Only" inside all the routes.
If someone who does not have "access" attempts to get the info, I res.sendStatus(403) "Forbidden".

To Be Added Later to the User PUT Routes:
Admin should only be able to change user TYPE - not the entire user body.