### PR TITLE
Product routing redo - refactoring and linking with the store

### DIFF
--- a/client/components/shop/Product-Single.js
+++ b/client/components/shop/Product-Single.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-
+import { loadAllProducts } from '../../store/products'
 
 class SingleProduct extends Component {
   constructor() {
@@ -11,6 +11,13 @@ class SingleProduct extends Component {
     }
     this.handleChange = this.handleChange.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
+  }
+
+  componentDidMount() {
+    if (!this.props.product) {
+      console.log('dispatching!')
+      this.props.fetchProducts()
+    }
   }
 
   handleSubmit(event) {
@@ -25,48 +32,78 @@ class SingleProduct extends Component {
   }
 
   render() {
-    const { id, title, description, price, inventoryQuantity, imageUrl } = this.props.location.props
-    console.log('props: ', this.props.location.props)
+    const { product } = this.props
+    // const title = product.title
+    // const description = product.description
+    // const price = product.price
+    // const inventoryQuantity = product.inventoryQuantity
+    // const imageUrl = product.imageUrl
+    //let title, description, price, inventoryQuantity, imageUrl
+    let quantity = 0
+    console.log('props: ', this.props)
+    let productContent
+    let price = 0
+    if (product) {
+      quantity = product.inventoryQuantity
+      price = product.price
+      productContent = (
+        <div>
+          <img src={product.imageUrl} />
+          {/* </div> */}
+          {/* <div className='single-prod-child'> */}
+          <h1>{product.title}</h1>
+          <p>{product.description}</p>
+          <h5>${product.price}</h5>
+        </div>
+      )
+    }
+    const loadingContent = (
+      <div>
+        <p>loading this product...</p>
+      </div>
+    )
     return (
       // classNames can be changed...flexbox in mind (2columns, pic vs everything else)
       //if it works better with something (bootstrap?), feel free to change classNames/div structure!
-      <div className='container-single-prod-parent'>
+      <div className="container-single-prod-parent">
         {/* <div className='single-prod-child'> */}
-          <img src={imageUrl} />
+        {product ? productContent : loadingContent}
+        <form>
+          <label>Select Quantity</label>
+          <select
+            name="product-quantity"
+            value={this.state.selectedQuantity}
+            onChange={this.handleChange}
+          >
+            {Array.apply(null, new Array(quantity)).map((el, ind) => {
+              return <option key={ind}>{ind}</option>
+            })}
+          </select>
+        </form>
+        <h5>Subtotal: ${this.state.selectedQuantity * price}</h5>
+        <button type="submit" onClick={this.handleSubmit}>
+          Add to cart
+        </button>
         {/* </div> */}
-        {/* <div className='single-prod-child'> */}
-          <h1>{title}</h1>
-          <p>{description}</p>
-          <h5>${price}</h5>
-          <form>
-            <label>Select Quantity</label>
-            <select
-              name='product-quantity'
-              value={this.state.selectedQuantity}
-              onChange={this.handleChange}>
-              {Array.apply(null, new Array(inventoryQuantity)).map((el, ind) => {
-                  return (<option key={ind}>{ind}</option>)
-                })}
-            </select>
-          </form>
-          <h5>Subtotal: ${this.state.selectedQuantity * price}</h5>
-          <button type='submit' onClick={this.handleSubmit}>Add to cart</button>
-        {/* </div> */}
-        <div>
-          {/* REVIEWS */}
-        </div>
+        <div>{/* REVIEWS */}</div>
       </div>
     )
   }
 }
-
-const mapDispatch = dispatch => {
+const mapStateToProps = (state, ownProps) => {
+  const id = Number(ownProps.match.params.productId)
   return {
-    test: () => dispatch('thing')
+    product: state.products.filter(product => product.id === id)[0],
+    products: state.products
+  }
+}
+const mapDispatchToProps = dispatch => {
+  return {
+    fetchProducts: () => dispatch(loadAllProducts())
   }
 }
 
-export default connect(null, mapDispatch)(SingleProduct)
+export default connect(mapStateToProps, mapDispatchToProps)(SingleProduct)
 
 // SingleProduct.propTypes = {
 //   id: PropTypes.string.isRequired,

--- a/client/components/shop/Product-Single.js
+++ b/client/components/shop/Product-Single.js
@@ -33,14 +33,8 @@ class SingleProduct extends Component {
 
   render() {
     const { product } = this.props
-    // const title = product.title
-    // const description = product.description
-    // const price = product.price
-    // const inventoryQuantity = product.inventoryQuantity
-    // const imageUrl = product.imageUrl
-    //let title, description, price, inventoryQuantity, imageUrl
+    //need some initial values for the form in case we still need to fetch the product
     let quantity = 0
-    console.log('props: ', this.props)
     let productContent
     let price = 0
     if (product) {
@@ -49,8 +43,6 @@ class SingleProduct extends Component {
       productContent = (
         <div>
           <img src={product.imageUrl} />
-          {/* </div> */}
-          {/* <div className='single-prod-child'> */}
           <h1>{product.title}</h1>
           <p>{product.description}</p>
           <h5>${product.price}</h5>

--- a/client/components/shop/product-card.js
+++ b/client/components/shop/product-card.js
@@ -8,7 +8,7 @@ export const ProductCard = props => {
   return (
     <div>
       <div className="card">
-        <Link to={`shop/product/${product.id}`}>
+        <Link to={`/shop/product/${product.id}`}>
           <img src={product.imageUrl} className="img img-fluid" />
           <h1>{product.title}</h1>
         </Link>

--- a/client/components/shop/product-card.js
+++ b/client/components/shop/product-card.js
@@ -2,17 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
-export const ProductCard = (props) => {
+export const ProductCard = props => {
   const { product } = props
 
   return (
     <div>
       <div className="card">
-        <Link to={{ pathname: `/product/${product.id}`, props: product}}>
+        <Link to={`shop/product/${product.id}`}>
           <img src={product.imageUrl} className="img img-fluid" />
           <h1>{product.title}</h1>
         </Link>
-          <p>Price: ${product.price}</p>
+        <p>Price: ${product.price}</p>
       </div>
     </div>
   )

--- a/client/main.js
+++ b/client/main.js
@@ -2,7 +2,14 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter, Route, Switch } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import { Login, Signup, UserDashboard, UserEdit, ProductList, ProductSingle } from './components'
+import {
+  Login,
+  Signup,
+  UserDashboard,
+  UserEdit,
+  ProductList,
+  ProductSingle
+} from './components'
 //import ProductList from './components/shop/product-list'
 import { me } from './store'
 
@@ -24,7 +31,11 @@ class Main extends Component {
         <Route path="/signup" component={Signup} />
         <Route exact path="/shop" component={ProductList} />
         <Route exact path="/shop/:categoryName" component={ProductList} />
-        <Route exact path="/product/:productId" component={ProductSingle} />
+        <Route
+          exact
+          path="/shop/product/:productId"
+          component={ProductSingle}
+        />
         {isLoggedIn && (
           <Switch>
             {/* Routes placed here are only available after logging in */}


### PR DESCRIPTION
Fixed a bug where the app would crash on product page refresh- we need to be able to get the product from the store in case it isn't already inherited. 
I also refactored the route for single product page, so that the urls match with the rest of the shop better: 
products/:productId => shop/products/:productId
So we should now be able to get to a single product page no matter where the request originated from!

